### PR TITLE
Implement nodal boundary conditions

### DIFF
--- a/src/FEMTruss.jl
+++ b/src/FEMTruss.jl
@@ -21,7 +21,7 @@ function get_unknown_field_name(::Problem{Truss})
 end
 
 function get_formulation_type(::Problem{Truss})
-    return :incremental
+    return :total
 end
 
 """

--- a/src/FEMTruss.jl
+++ b/src/FEMTruss.jl
@@ -12,6 +12,12 @@ import FEMBase: get_unknown_field_name,
 
 """
 This truss fromulation is from
+
+# Features
+- Nodal forces can be set using element `Poi1` with field
+  `nodal force i`, where `i` is dof number.
+- Displacements can be fixed using element `Poi1` with field
+  `fixed displacement i`, where `i` is dof number.
 """
 type Truss <: FieldProblem
 end
@@ -79,6 +85,36 @@ function assemble!(assembly::Assembly, problem::Problem{Truss},
     gdofs = get_gdofs(problem, element)
     add!(assembly.K, gdofs, gdofs, K)
     #add!(assembly.f, gdofs, f)
+end
+
+import FEMBase: assemble_elements!
+
+function assemble_elements!(problem::Problem, assembly::Assembly,
+                            elements::Vector{Element{Poi1}}, time::Float64)
+    dim = ndofs = get_unknown_field_dimension(problem)
+    Ce = zeros(ndofs,ndofs)
+    ge = zeros(ndofs)
+    fe = zeros(ndofs)
+    for element in elements
+        fill!(Ce, 0.0)
+        fill!(ge, 0.0)
+        fill!(fe, 0.0)
+        ip = (0.0,)
+        for i=1:dim
+            if haskey(element, "fixed displacement $i")
+                Ce[i,i] = 1.0
+                ge[i] = element("fixed displacement $i", ip, time)
+            end
+            if haskey(element, "nodal force $i")
+                fe[i] = element("nodal force $i", ip, time)
+            end
+        end
+        gdofs = get_gdofs(problem, element)
+        add!(assembly.C1, gdofs, gdofs, Ce)
+        add!(assembly.C2, gdofs, gdofs, Ce)
+        add!(assembly.g, gdofs, ge)
+        add!(assembly.f, gdofs, fe)
+    end
 end
 
 export Truss

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -3,6 +3,7 @@
 
 using FEMBase
 using FEMTruss
+using FEMBase: get_formulation_type
 
 using Base.Test
 # thsi is the same for all tests testing K and orientation
@@ -36,7 +37,7 @@ p1 = make_test_problem(X, ndofs)
 #Test threw an exception of type UndefVarError
 #  Expression: get_formulation_type(p1)
 #  UndefVarError: get_formulation_type not defined
-#@test get_formulation_type(p1)
+@test get_formulation_type(p1) == :total
 
 K_truss = full(p1.assembly.K)
 K_oracle =  K_oracle_base

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -94,3 +94,20 @@ K_oracle = trans'*K_oracle_base*trans
 @test isapprox(K_truss, K_oracle)
 
 end
+
+@testset "test nodal elements" begin
+    element = Element(Poi1, [1])
+    update!(element, "fixed displacement 1", 1.0)
+    update!(element, "nodal force 2", 2.0)
+    problem = Problem(Truss, "test problem", 2)
+    add_elements!(problem, [element])
+    assemble!(problem, 0.0)
+    C1 = full(problem.assembly.C1, 2, 2)
+    C2 = full(problem.assembly.C2, 2, 2)
+    f = full(problem.assembly.f, 2, 1)
+    g = full(problem.assembly.g, 2, 1)
+    @test isapprox(C1, [1.0 0.0; 0.0 0.0])
+    @test isapprox(C1, C2)
+    @test isapprox(f, [0.0, 2.0])
+    @test isapprox(g, [1.0, 0.0])
+end

--- a/test/test_problems.jl
+++ b/test/test_problems.jl
@@ -2,11 +2,41 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMTruss.jl/blob/master/LICENSE
 
 using FEMBase
+using FEMBase.Test
 using FEMTruss
 
-using Base.Test
-
 @testset "FEMTrussProblems.jl" begin
-# Do a simple truss system with two trusses in 45 deg.
-# three nodes and and horizontal andf vertical nodes in
+    E = 400.0*sqrt(5)
+    A = 0.1
+    Fx = 6.4*sqrt(2)
+    Fy = 1.6*sqrt(2)
+    X = Dict(1 => [0.0, 0.0],
+             2 => [0.0, 1.0],
+             3 => [1.0, 0.5])
+    el1 = Element(Seg2, [1, 3])
+    el2 = Element(Seg2, [2, 3])
+    bel1 = Element(Poi1, [1])
+    bel2 = Element(Poi1, [2])
+    bel3 = Element(Poi1, [3])
+    elements = [el1, el2, bel1, bel2, bel3]
+    update!(elements, "geometry", X)
+
+    update!([bel1, bel2], "fixed displacement 1", 0.0)
+    update!([bel1, bel2], "fixed displacement 2", 0.0)
+    update!(bel3, "nodal force 1", Fx)
+    update!(bel3, "nodal force 2", Fy)
+    update!(elements, "youngs modulus", E)
+    update!(elements, "cross section area", A)
+
+    problem = Problem(Truss, "test problem", 2)
+    add_elements!(problem, elements)
+
+    # solution
+    step = Analysis(Static)
+    add_problems!(step, [problem])
+    ls, normu, normla = run!(step)
+    println("K = ", full(ls.K))
+    println("f = ", full(ls.f))
+    println("u = ", full(ls.u))
+    println("la = ", full(ls.la))
 end


### PR DESCRIPTION
* Using element `Poi1`, one can use field `nodal force i` where `i` is a dof number, to set nodal force / concentrated load (CLOAD in Abaqus).
* Using element `Poi1`, one can use field `fixed displacement i`, where `i` is a dof number, to fix displacement in some node.
* Wrote a test to test nodal elements + 2 truss test.